### PR TITLE
Fix blog workflow provider handling

### DIFF
--- a/src/utils/__tests__/workflows.test.js
+++ b/src/utils/__tests__/workflows.test.js
@@ -1,0 +1,14 @@
+import latestBlogs from '../workflows';
+
+describe('latestBlogs', () => {
+  it('handles no blog providers selected', () => {
+    const payload = {
+      dev: { show: false, username: '' },
+      rssurl: { show: false, username: '' },
+      medium: { show: false, username: '' },
+    };
+
+    const data = latestBlogs(payload);
+    expect(data).toContain('feed_list: ""');
+  });
+});

--- a/src/utils/workflows.js
+++ b/src/utils/workflows.js
@@ -38,14 +38,18 @@ export default function latestBlogs(payload) {
     rssFeed = `https://dev.to/feed/${payload.dev.username}`;
   } else if (payload.rssurl.show && payload.rssurl.username) {
     rssFeed = payload.rssurl.username;
-  } else {
+  } else if (
+    payload.medium.show &&
+    payload.medium.username &&
+    isMediumUsernameValid(payload.medium.username)
+  ) {
     rssFeed = `https://medium.com/feed/${payload.medium.username}`;
   }
   const data = `name: Latest blog post workflow
-on: 
+on:
     schedule:
         - cron: '0 * * * *'
-jobs: 
+jobs:
     update-readme-with-blog: 
         name: Update this repo's README with latest blog posts
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- handle missing blog providers in workflow generator
- add regression test for workflow feed list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ee4bc68388332bf47ec35bb4e71e2